### PR TITLE
Change base container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM vcatechnology/arch:latest
 MAINTAINER VCA Technology <developers@vcatechnology.com>
 
 RUN pacman --noconfirm --needed -S \
+  git \
   bash-bats \
   openssh \
   tar \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM vcatechnology/arch-ci:latest
+FROM vcatechnology/arch:latest
 MAINTAINER VCA Technology <developers@vcatechnology.com>
 
-RUN sudo pacman --noconfirm --needed -S \
+RUN pacman --noconfirm --needed -S \
   bash-bats \
   openssh \
   tar \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,5 @@ RUN pacman --noconfirm --needed -S \
   tar \
   bzip2 \
   gzip \
-  xz
+  xz \
+  && pacman --noconfirm -Scc

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ image has the latest [Arch Linux](https://www.archlinux.org/) packages. It then
 installs the some useful development packages.
 
 ## Packages
-  - [`bash-bats`](https://www.archlinux.org/packages/extra/x86_64/bash-bats/)
-  - [`openssh`](https://www.archlinux.org/packages/extra/x86_64/openssh/)
-  - [`tar`](https://www.archlinux.org/packages/extra/x86_64/tar/)
-  - [`bzip2`](https://www.archlinux.org/packages/extra/x86_64/bzip2/)
-  - [`gzip`](https://www.archlinux.org/packages/extra/x86_64/gzip/)
-  - [`xz`](https://www.archlinux.org/packages/extra/x86_64/xz/)
+  - [`bash-bats`](https://www.archlinux.org/packages/community/x86_64/bash-bats/)
+  - [`openssh`](https://www.archlinux.org/packages/core/x86_64/openssh/)
+  - [`tar`](https://www.archlinux.org/packages/core/x86_64/tar/)
+  - [`bzip2`](https://www.archlinux.org/packages/core/x86_64/bzip2/)
+  - [`gzip`](https://www.archlinux.org/packages/core/x86_64/gzip/)
+  - [`xz`](https://www.archlinux.org/packages/core/x86_64/xz/)
 


### PR DESCRIPTION
We don't need the packags that `arch-ci` installs. We can just install our packages on top using the root user.